### PR TITLE
fixed little-endian not working

### DIFF
--- a/src/enums/bitOrder.ts
+++ b/src/enums/bitOrder.ts
@@ -6,10 +6,10 @@ export enum BitOrder {
     /**
      * Use little-endian byte sorting
      */
-    LE,
+    LE = 1,
     
     /**
      *  Use big-endian byte sorting
      */
-    BE
+    BE = 2
 }


### PR DESCRIPTION
(<NumberMetadata>meta).bitOrder = (<NumberMetadata>meta).bitOrder || defs.bitOrder || BitOrder.BE; is not working because
0 || 0 || 1 will always return 1 and not 0.
changed enum to values that are not 0